### PR TITLE
Added raven and underscore dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "type": "git",
     "url": "https://github.com/guzru/winston-sentry.git"
   },
+  "dependencies": {
+    "raven": "",
+    "underscore": ""
+  },
   "keywords": [
     "node",
     "sentry",


### PR DESCRIPTION
Maybe I'm missing something but sentry-transport.js requires `util`, `raven`, `winston` and `underscore` and only winston and util are guaranteed to be available.
