### PR TITLE
Pin dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/guzru/winston-sentry.git"
   },
   "dependencies": {
-    "raven": "",
-    "underscore": ""
+    "raven": "0.4.x",
+    "underscore": "1.4.2"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
Dependencies should be pinned to a specific compatible version.

I know for `raven`, we're working on some potentially radical updates that will potentially break backwards compatibility come `v1.0`, so I want to make sure that libraries that depend on `raven` don't break. :)
