### PR TITLE
Use peerDependencies for Winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "raven": "0.4.x",
     "underscore": "1.4.2"
   },
+  "peerDependencies": {
+    "winston": ">= 0.7.0"
+  },
   "keywords": [
     "node",
     "sentry",


### PR DESCRIPTION
This should be a best practice for plugin projects. See http://blog.nodejs.org/2013/02/07/peer-dependencies/.
