### PR TITLE
Add support for request context and user context

### DIFF
--- a/sentry-transport.js
+++ b/sentry-transport.js
@@ -56,6 +56,16 @@ Sentry.prototype.log = function (level, msg, meta, callback) {
     'tags': tags
   };
 
+  if (extraData.request) {
+    extra.request = extraData.request;
+    delete extraData.request;
+  }
+
+  if (extraData.user) {
+    extra.user = extraData.user;
+    delete extraData.user;
+  }
+
   try {
     if(level == 'error') {
       // Support exceptions logging


### PR DESCRIPTION
If the user passes request and user context in the extra data pass them to the top level of the meta (same as in tags context)
