### PR TITLE
Update raven and some other general improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ var logger = new winston.Logger({
     transports: [
         new winston.transports.Console({level: 'silly'}),
         new Sentry({
-                level: 'warn',
-                dsn: "{{ YOUR SENTRY DSN }}"
+            level: 'warn',
+            dsn: "{{ YOUR SENTRY DSN }}",
+            tags: { key: 'value' },
+            extra: { key: 'value' }
         })
     ],
 });
@@ -29,27 +31,35 @@ new Sentry({
     patchGlobal: true
 });
 ```
-    
+
 Winston logging levels are mapped to the default sentry levels like this:
 
+```javascript
+{
     silly: 'debug',
     verbose: 'debug',
     info: 'info',
     debug: 'debug',
     warn: 'warning',
-    error: 'error',
-    
+    error: 'error'
+}
+```
+
+You can customize how log levels are mapped using the `levelsMap` option:
+
+```javascript
+new Sentry({
+    levelsMap: {
+        verbose: 'info'
+    }
+});
+```
+
 Changelog
 ---------
 
 **0.1.1**
 * Added support for global tags that will be added to every message sent to sentry
-
-```javascript
-new Sentry({
-    globalTags: { foo: "bar" }
-})
-```
 
 **0.1.0**
 * Upgrade Raven client to version 0.8.1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "raven": "^0.8.1",
-    "underscore": "1.8.3"
+    "lodash": "^4.12.0",
   },
   "peerDependencies": {
     "winston": ">= 0.7.0"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "https://github.com/guzru/winston-sentry.git"
   },
   "dependencies": {
-    "raven": "^0.8.1",
     "lodash": "^4.12.0",
+    "raven": "^0.11.0"
   },
   "peerDependencies": {
     "winston": ">= 0.7.0"
@@ -27,8 +27,8 @@
   "author": "Cristiano Valente",
   "contributors": [
     {
-      "name" : "Shahar Kedar",
-      "url" : "https://github.com/shaharke/"
+      "name": "Shahar Kedar",
+      "url": "https://github.com/shaharke/"
     }
   ],
   "license": "BSD"

--- a/sentry-transport.js
+++ b/sentry-transport.js
@@ -1,7 +1,7 @@
 var util = require('util'),
     raven = require('raven'),
     winston = require('winston'),
-    _ = require('underscore');
+    _ = require('lodash');
 
 var Sentry = winston.transports.Sentry = function (options) {
 

--- a/sentry-transport.js
+++ b/sentry-transport.js
@@ -23,6 +23,9 @@ var Sentry = winston.transports.Sentry = function (options) {
     extra: {}
   }
 
+  // For backward compatibility with deprecated `globalTags` option
+  options.tags = options.tags || options.globalTags;
+
   this.options = _.defaultsDeep(options, this.defaults);
 
   this._sentry = this.options.raven || new raven.Client(this.options.dsn, this.options);


### PR DESCRIPTION
## In this PR
- Updated `raven` to the latest version
- Changed from `underscore` to `lodash`
- Store all default options in `this.defaults` object
- Merge user options with defaults using lodash `_.defaultsDeep()` for compatibility with future raven features

## Breaking Change
All options passed to `winston-sentry` now mirror those used by `raven`. This means the previous `globalTags` option is now named `tags`.