### PR TITLE
Fixes #30: Transport should not ignore configured log level

### DIFF
--- a/sentry-transport.js
+++ b/sentry-transport.js
@@ -4,13 +4,13 @@ var util = require('util'),
     _ = require('lodash');
 
 var Sentry = winston.transports.Sentry = function (options) {
+  winston.Transport.call(this, _.pick(options, "level"));
 
   // Default options
   this.defaults = {
     dsn: '',
     patchGlobal: false,
     logger: 'root',
-    level: 'info',
     levelsMap: {
       silly: 'debug',
       verbose: 'debug',


### PR DESCRIPTION
Fixes #31: Sometimes I'm baffled by inheritance in JavaScript... 

Before 0.1.2 the level was extracted from `options` and was set on `this`:

```javascript
  // Set the level from your options
  this.level = options.level || 'info';
```

This was omitted in the latest release. I think that it's best to call the constructor of `winston.Transport` with the relevant options instead of setting those options on `this`. IMO it makes it clearer that those properties are intended for the parent class and not for the child. 

@adambiggs WDYT?